### PR TITLE
Add linear regression training script

### DIFF
--- a/train_volume_model.py
+++ b/train_volume_model.py
@@ -1,0 +1,27 @@
+import pandas as pd
+from sklearn.linear_model import LinearRegression
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import mean_squared_error
+
+
+def main():
+    df = pd.read_csv('outputs/clean_dataset.csv')
+    if 'volume_y' in df.columns:
+        df = df.rename(columns={'volume_y': 'volume'})
+    X = df[['close', 'circulating_supply', 'holders']]
+    y = df['volume']
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, shuffle=False
+    )
+
+    model = LinearRegression()
+    model.fit(X_train, y_train)
+
+    y_pred = model.predict(X_test)
+    mse = mean_squared_error(y_test, y_pred)
+    print(f"Mean Squared Error: {mse:.2f}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- Add script to train a Linear Regression model on `clean_dataset.csv`
- Predicts volume from close, circulating_supply, and holders with a fixed train/test split

## Testing
- `python train_volume_model.py`

------
https://chatgpt.com/codex/tasks/task_e_68b09056176c83268e5a411b59147b27